### PR TITLE
Reload systemd-networkd.service during ensure-sysext

### DIFF
--- a/systemd/system/ensure-sysext.service
+++ b/systemd/system/ensure-sysext.service
@@ -12,6 +12,7 @@ ConditionDirectoryNotEmpty=|/usr/lib/extensions
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/systemctl daemon-reload
+ExecStart=/usr/bin/systemctl reload systemd-networkd.service
 ExecStart=/usr/bin/systemctl restart --no-block sockets.target timers.target multi-user.target
 [Install]
 WantedBy=sysinit.target


### PR DESCRIPTION
Supports sysexts that configure networkd (for example, tailscale)